### PR TITLE
Fix unused exception variable

### DIFF
--- a/weather_app/app.py
+++ b/weather_app/app.py
@@ -61,7 +61,7 @@ def format_bom_local_time(time_str):
                 }
         # If neither format matches, mark as malformed
         raise ValueError("Unknown time string format")
-    except Exception as e:
+    except Exception:
         # print(f"Debug: Could not parse time_str '{time_str}': {e}") # Optional debug
         return {'date': 'N/A', 'time': 'N/A', 'original': time_str, 'malformed': True}
 


### PR DESCRIPTION
## Summary
- clean up `format_bom_local_time` error handling by removing unused variable

## Testing
- `python -m py_compile weather_app/app.py`
- `ruff check weather_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f89fefe6c8326a233b34884254f80